### PR TITLE
attempt to fix broken startup

### DIFF
--- a/Geo_Data_dialog.py
+++ b/Geo_Data_dialog.py
@@ -142,7 +142,14 @@ class GeoDataDialog(QtWidgets.QDialog, FORM_CLASS):
             # retain values that are unititialized in current source,
             # but were initiarized in some of the previous
             config = configparser.ConfigParser()
-            config.read(os.path.join(sources_dir, path, 'metadata.ini'))
+            config_file = os.path.join(sources_dir, path, 'metadata.ini')
+            try:
+                config.read(config_file)
+            except UnicodeDecodeError as e:
+                iface.messageBar().pushMessage(
+                    "Error", "Unable load {}: {}".format(config_file, e), level=Qgis.Critical)
+                continue
+
             current_group = path.split("_")[0]
             if current_group != group:
                 group = current_group
@@ -154,20 +161,25 @@ class GeoDataDialog(QtWidgets.QDialog, FORM_CLASS):
             url = ""
             proc_class = None
             service_name = None
-            if "WMS" in config['general']['type'] or "TMS" in config['general']['type']:
-                url = self.get_url(config)
+            try:
+                if "WMS" in config['general']['type'] or "TMS" in config['general']['type']:
+                    url = self.get_url(config)
 
-                if config['general']['type'].upper() == 'WMS' and config.has_option("wms", "service_name"):
-                    service_name = config["wms"]["service_name"]
+                    if config['general']['type'].upper() == 'WMS' and config.has_option("wms", "service_name"):
+                        service_name = config["wms"]["service_name"]
 
-            elif "WMTS" in config['general']['type']:
-                url = self.get_url(config)
+                elif "WMTS" in config['general']['type']:
+                    url = self.get_url(config)
 
-                if config.has_option("wmts", "service_name"):
-                    service_name = config["wmts"]["service_name"]
+                    if config.has_option("wmts", "service_name"):
+                        service_name = config["wmts"]["service_name"]
 
-            elif "PROC" in config['general']['type']:
-                proc_class = self.get_proc_class(path)
+                elif "PROC" in config['general']['type']:
+                    proc_class = self.get_proc_class(path)
+            except KeyError as e:
+                iface.messageBar().pushMessage(
+                    "Error", "Invalid metadata {} (missing key {})".format(config_file, e), level=Qgis.Critical)
+                continue
 
             self.data_sources.append(
                 {

--- a/Region_dialog.py
+++ b/Region_dialog.py
@@ -77,7 +77,7 @@ class RegionDialog(QtWidgets.QDialog, FORM_CLASS):
         s.setValue("geodata_cz_sk/region", region)
         if self.start:
             self.hide()
-            gdd = GeoDataDialog(self.iface)
+            gdd = GeoDataDialog(self.iface, self)
             gdd.show()
             gdd.exec_()
         else:


### PR DESCRIPTION
Plugin is complete broken, it doesn't start...

This PR should fix two issues:

```
Traceback (most recent call last):
              File "/home/martin/git/opengeolabs/czech_slovak_freegeodata/../czech_slovak_freegeodata/Geo_Data.py", line 195, in run
              self.dlg_main = GeoDataDialog(self.iface, self.dlg_region)
              File "/home/martin/git/opengeolabs/czech_slovak_freegeodata/../czech_slovak_freegeodata/Geo_Data_dialog.py", line 70, in __init__
              self.load_sources_into_tree()
              File "/home/martin/git/opengeolabs/czech_slovak_freegeodata/../czech_slovak_freegeodata/Geo_Data_dialog.py", line 145, in load_sources_into_tree
              config.read(os.path.join(sources_dir, path, 'metadata.ini'))
              File "/usr/lib/python3.9/configparser.py", line 697, in read
              self._read(fp, filename)
              File "/usr/lib/python3.9/configparser.py", line 1017, in _read
              for lineno, line in enumerate(fp, start=1):
              File "/usr/lib/python3.9/codecs.py", line 322, in decode
              (result, consumed) = self._buffer_decode(data, self.errors, final)
             UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe1 in position 130: invalid continuation byte
             
Traceback (most recent call last):
              File "/home/martin/git/opengeolabs/czech_slovak_freegeodata/../czech_slovak_freegeodata/Region_dialog.py", line 90, in setRegionCZE
              self.setRegion("CZE")
              File "/home/martin/git/opengeolabs/czech_slovak_freegeodata/../czech_slovak_freegeodata/Region_dialog.py", line 80, in setRegion
              gdd = GeoDataDialog(self.iface)
             TypeError: __init__() missing 1 required positional argument: 'regiondialog'
```