### PR TITLE
fix start (headerview + DuplicateOptionError)

### DIFF
--- a/Geo_Data_dialog.py
+++ b/Geo_Data_dialog.py
@@ -136,7 +136,7 @@ class GeoDataDialog(QtWidgets.QDialog, FORM_CLASS):
         self.treeWidgetSources.itemChanged.connect(self.handleChanged)
         self.treeWidgetSources.itemSelectionChanged.connect(self.handleSelected)
         tree = self.treeWidgetSources
-        tree.header().setResizeMode(0,QHeaderView.ResizeToContents)
+        tree.header().setSectionResizeMode(0,QHeaderView.ResizeToContents)
         paths = []
 
         sources_dir = os.path.join(self.current_dir, 'data_sources')
@@ -158,7 +158,7 @@ class GeoDataDialog(QtWidgets.QDialog, FORM_CLASS):
             config_file = os.path.join(sources_dir, path, 'metadata.ini')
             try:
                 config.read(config_file)
-            except UnicodeDecodeError as e:
+            except (UnicodeDecodeError, configparser.DuplicateOptionError) as e:
                 iface.messageBar().pushMessage(
                     "Error", "Unable load {}: {}".format(config_file, e), level=Qgis.Critical)
                 continue


### PR DESCRIPTION
Currently plugin doesn't start due to critical bug:

```
2021-05-27T11:52:27     WARNING    Traceback (most recent call last):
              File "/home/martin/git/ctu-fgis/2021-a-czech_slovak_freegeodata/../2021-a-czech_slovak_freegeodata/Geo_Data.py", line 195, in run
              self.dlg_main = GeoDataDialog(self.iface, self.dlg_region)
              File "/home/martin/git/ctu-fgis/2021-a-czech_slovak_freegeodata/../2021-a-czech_slovak_freegeodata/Geo_Data_dialog.py", line 82, in __init__
              self.load_sources_into_tree()
              File "/home/martin/git/ctu-fgis/2021-a-czech_slovak_freegeodata/../2021-a-czech_slovak_freegeodata/Geo_Data_dialog.py", line 139, in load_sources_into_tree
              tree.header().setResizeMode(0,QHeaderView.ResizeToContents)
             AttributeError: 'QHeaderView' object has no attribute 'setResizeMode'
```